### PR TITLE
introduce concept of "upgradeable nodes"

### DIFF
--- a/sphinx/builders/__init__.py
+++ b/sphinx/builders/__init__.py
@@ -52,6 +52,9 @@ if False:
 logger = logging.getLogger(__name__)
 
 
+def list_tree(node):
+    return node, list(map(list_tree, node.children))
+
 class Builder:
     """
     Builds target formats from the reST sources.
@@ -539,7 +542,12 @@ class Builder:
         doctree_filename = path.join(self.doctreedir, docname + '.doctree')
         ensuredir(path.dirname(doctree_filename))
         with open(doctree_filename, 'wb') as f:
-            pickle.dump(doctree, f, pickle.HIGHEST_PROTOCOL)
+            try:
+                pickle.dump(doctree, f, pickle.HIGHEST_PROTOCOL)
+            except TypeError as e:
+                tree = list_tree(doctree)
+                import ipdb;ipdb.set_trace()
+                raise
 
     def write(self, build_docnames, updated_docnames, method='update'):
         # type: (Iterable[unicode], Sequence[unicode], unicode) -> None

--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -325,7 +325,7 @@ class Only(SphinxDirective):
 
     def run(self):
         # type: () -> List[nodes.Node]
-        node = addnodes.only()
+        node = self.env.app.create_node(addnodes.only, sender=self)
         node.document = self.state.document
         set_source_info(self, node)
         node['expr'] = self.arguments[0]

--- a/sphinx/environment/collectors/toctree.py
+++ b/sphinx/environment/collectors/toctree.py
@@ -17,6 +17,7 @@ from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.locale import __
 from sphinx.transforms import SphinxContentsFilter
 from sphinx.util import url_re, logging
+from sphinx.util.nodes import subclasses_of
 
 if False:
     # For type annotation
@@ -84,8 +85,8 @@ class TocTreeCollector(EnvironmentCollector):
                 # find all toctree nodes in this section and add them
                 # to the toc (just copying the toctree node which is then
                 # resolved in self.get_and_resolve_doctree)
-                if isinstance(sectionnode, addnodes.only):
-                    onlynode = addnodes.only(expr=sectionnode['expr'])
+                if isinstance(sectionnode, subclasses_of(addnodes.only)):
+                    onlynode = app.create_node(addnodes.only, expr=sectionnode['expr'], event_sender=self)
                     blist = build_toc(sectionnode, depth)
                     if blist:
                         onlynode += blist.children  # type: ignore
@@ -159,7 +160,7 @@ class TocTreeCollector(EnvironmentCollector):
                 elif isinstance(subnode, nodes.list_item):
                     _walk_toc(subnode, secnums, depth, titlenode)
                     titlenode = None
-                elif isinstance(subnode, addnodes.only):
+                elif isinstance(subnode, subclasses_of(addnodes.only)):
                     # at this stage we don't know yet which sections are going
                     # to be included; just include all of them, even if it leads
                     # to gaps in the numbering

--- a/sphinx/events.py
+++ b/sphinx/events.py
@@ -40,6 +40,7 @@ core_events = {
     'html-collect-pages': 'builder',
     'html-page-context': 'pagename, context, doctree or None',
     'build-finished': 'exception',
+    'upgrade-node': 'current_version, previous_version, sender',
 }  # type: Dict[unicode, unicode]
 
 

--- a/sphinx/ext/linkcode.py
+++ b/sphinx/ext/linkcode.py
@@ -70,7 +70,7 @@ def doctree_read(app, doctree):
                 continue
             uris.add(uri)
 
-            onlynode = addnodes.only(expr='html')
+            onlynode = app.create_node(addnodes.only, expr='html', event_sender=__name__)
             onlynode += nodes.reference('', '', internal=False, refuri=uri)
             onlynode[0] += nodes.inline('', _('[source]'),
                                         classes=['viewcode-link'])

--- a/sphinx/ext/viewcode.py
+++ b/sphinx/ext/viewcode.py
@@ -120,7 +120,7 @@ def doctree_read(app, doctree):
                 continue
             names.add(fullname)
             pagename = '_modules/' + modname.replace('.', '/')
-            onlynode = addnodes.only(expr='html')
+            onlynode = app.create_node(addnodes.only, expr='html', event_sender=__name__)
             onlynode += addnodes.pending_xref(
                 '', reftype='viewcode', refdomain='std', refexplicit=False,
                 reftarget=pagename, refid=fullname,

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -345,6 +345,22 @@ indextypes = [
     'single', 'pair', 'double', 'triple', 'see', 'seealso',
 ]
 
+def subclasses_of(node_class, include_self=True):
+    return tuple(get_subclasses(node_class, include_self))
+
+def get_subclasses(node_class, include_self=True):
+    if include_self:
+        yield node_class
+
+    for subclass in node_class.__subclasses__():
+        yield from get_subclasses(subclass, include_self=False)
+        yield subclass
+
+def traverse_subclasses_of(node_class, document):
+    for node_class in subclasses_of(node_class):
+        for node in document.traverse(node_class):
+            yield node
+
 
 def process_index_entry(entry, targetid):
     # type: (unicode, unicode) -> List[Tuple[unicode, unicode, unicode, unicode, unicode]]
@@ -474,7 +490,7 @@ def is_smartquotable(node):
 def process_only_nodes(document, tags):
     # type: (nodes.Node, Tags) -> None
     """Filter ``only`` nodes which does not match *tags*."""
-    for node in document.traverse(addnodes.only):
+    for node in traverse_subclasses_of(addnodes.only, document):
         try:
             ret = tags.eval_condition(node['expr'])
         except Exception as err:


### PR DESCRIPTION
This is an attempt to make sphinx even more extensible.

----

- add event "upgrade-node"
- introduce new methods to `application.Sphinx`
  - `create_node` - to create nodes that can be modified in runtime by listener callbacks
  - `upgrade_node` - upgrades a newly created node
- replace all occurrences of `addnodes.only()` with `app.create_node(addnodes.only)`
- introduce function `sphinx.util.nodes.subclasses_of`
- introduce function `sphinx.util.nodes.traverse_subclasses_of`
- replace all occurrences of `document.traverse(addnodes.only)` with `traverse_subclasses_of(addnodes.only, document)`

# Extension used for testing concept

```python
# fmt: off
import logging

from docutils import nodes

from sphinx import addnodes

from sphinx.directives.other import Only

from sphinx.transforms import SphinxTransform
from sphinx.transforms.post_transforms import OnlyNodeTransform

from sphinx.util.docutils import SphinxDirective
from sphinx.util.nodes import process_only_nodes
from sphinx.util.nodes import set_source_info

version = '0.0.1'
logger = logging.getLogger(__name__)


def wrap_children_in_container(node, css_class_name):
    wrappernode = nodes.container(classes=[css_class_name])
    wrappernode.extend(node.children)
    node.replace_self(wrappernode)

def process_conditional_output_nodes(document, tags):
    """similar to :py:func:`~sphinx.uti.nodes.process_only_nodes` but
    wraps children in a container and adds a css class for styling.
    """
    for node in document.traverse(conditional_output):
        css_class_name = node['expr']
        try:
            ret = tags.eval_condition(css_class_name)
        except Exception as err:
            self.wrap_children_in_container(node, css_class_name)

        else:
            if ret:
                wrap_children_in_container(node, css_class_name)
            else:
                # A comment on the comment() nodes being inserted: replacing by [] would
                # result in a "Losing ids" exception if there is a target node before
                # the only node, so we make sure docutils can transfer the id to
                # something, even if it's just a comment and will lose the id anyway...
                node.replace_self(nodes.comment())


class conditional_output(nodes.General, nodes.Element):
    pass



class ConditionalOutput(SphinxDirective):
    """pretty much a clone of :py:class:`sphinx.directive.other.Only`
    """
    has_content = True
    required_arguments = 1
    optional_arguments = 0
    final_argument_whitespace = True
    option_spec = {}

    only_node_class = conditional_output

    def run(self):
        # self.app.events.connect('upgrade-node', self.upgrade_node)
        return [conditional_output()]

    def upgrade_node(self, current_version, previous_version, sender):
        if isinstance(sender, Only):
            import ipdb;ipdb.set_trace()

        # if sender == self and isinstance(current_version, addnodes.only):
        #     return current_version

        # if not isinstance(sender, Only) and not isinstance(current_version, addnodes.only):
        #     return current_version

        # import ipdb;ipdb.set_trace()
        # node = self.app.create_node(addnodes.conditional_output, expr=self.arguments[0])
        # return node

class ConditionalOutputTransformer(OnlyNodeTransform):
    """This is pretty much a copy of

    :py:func:`sphinx.util.nodes.process_only_nodes` except it wraps all
    children in a common container and the code is cleaner :)

    """
    default_priority = OnlyNodeTransform.default_priority - 10

    def apply(self):
        self.app.events.connect('upgrade-node', self.upgrade_node)
        super(ConditionalOutputTransformer, self).apply()

    def upgrade_node(self, current_version, previous_version, sender=None):
        if isinstance(sender, Only):
            import ipdb;ipdb.set_trace()

        # if current_version == previous_version:
        #     return None

        # import ipdb;ipdb.set_trace()
        # if sender == self and isinstance(current_version, addnodes.only):
        #     import ipdb;ipdb.set_trace()
        #     return None

        # if not isinstance(sender, Only) and not isinstance(current_version, addnodes.only):
        #     return None

        # if isinstance(current_version, conditional_output):
        #     process_conditional_output_nodes(self.document, self.app.builder.tags)


def setup(app):
    app.add_node(conditional_output)
    app.add_directive("conditional_output", ConditionalOutput)
    app.add_transform(ConditionalOutputTransformer)

    return {
        'version': version,
        'parallel_read_safe': True,
        'parallel_write_safe': True,
    }

```